### PR TITLE
TSLint config

### DIFF
--- a/src/test/server.test.ts
+++ b/src/test/server.test.ts
@@ -1,4 +1,3 @@
-/* tslint:disable */
 import app from '../index'
 import supertest from 'supertest'
 const request = supertest(app)

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,14 @@
     "quotemark": [true, "single", "avoid-escape"],
     "interface-name": [false],
     "object-literal-sort-keys": false,
-    "max-classes-per-file": false
+    "max-classes-per-file": false,
+    "ordered-imports": [
+      true,
+      {
+        "import-sources-order": "any",
+        "named-imports-order": "any"
+      }
+    ]
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Although we have solved the issue by having `/* tslint:disable */` in the server tests, I was curious to see whether we could solve this issue by tweaking the TSLint rules.

This PR changes the TSLint config to prevent re-ordering of imports. This change allows imports to be in any order, rather than having them alphabetical.

Just in case anyone is interested in other TSLint configs that are out there: https://palantir.github.io/tslint/rules/